### PR TITLE
Updated the build script for the generated browser folder

### DIFF
--- a/browser/phaserjs_editor_scripts_quick/animations/FadeActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/FadeActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/MoveInSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/MoveInSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/MoveOutSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/MoveOutSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/PushActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/PushActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/arcade/GetGameObjectFromBodyActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/GetGameObjectFromBodyActionScript.js
@@ -1,7 +1,7 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
-import { ActionTargetComp } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
+import { ActionTargetComp } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class GetGameObjectFromBodyActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/IfBodyTouchingScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/IfBodyTouchingScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 import ExecChildrenActionScript from "../core/ExecChildrenActionScript.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/arcade/MakeObjectColliderActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/MakeObjectColliderActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class MakeObjectColliderActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetBodyEnableActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetBodyEnableActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetBodyEnableActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityXActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityYActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/StartFlipWithVelocityAction.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/StartFlipWithVelocityAction.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartFlipWithVelocityAction extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/StartFollowPointerActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/StartFollowPointerActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartFollowPointerActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/AudioPauseAllActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/AudioPauseAllActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AudioPauseAllActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/PlaySoundActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/PlaySoundActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AudioLoopConfigComp from "./AudioLoopConfigComp.js";
 import AudioVolumeConfigComp from "./AudioVolumeConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/audio/ResumeAllAudioActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/ResumeAllAudioActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ResumeAllAudioActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/StopAllSoundsActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/StopAllSoundsActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StopAllSoundsActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/StopSoundActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/StopSoundActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StopSoundActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/CameraStartFollowActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/CameraStartFollowActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CameraStartFollowActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/CameraStopFollowActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/CameraStopFollowActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CameraStopFollowActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/FadeCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/FadeCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/camera/FlashCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/FlashCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import FadeCameraActionScript from "./FadeCameraActionScript.js";
 import DurationConfigComp from "../animations/DurationConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/camera/ShakeCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/ShakeCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/camera/ZoomCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/ZoomCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 import EaseConfigComp from "../animations/EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/core/AddToParentActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/AddToParentActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AddToParentActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/AlertActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/AlertActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AlertActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/CallbackActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/CallbackActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CallbackActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ConsoleLogActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ConsoleLogActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ConsoleLogActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/DestroyActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/DestroyActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class DestroyActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/EmitEventActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/EmitEventActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class EmitEventActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecChildrenActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecChildrenActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecChildrenActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecRandomActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecRandomActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecRandomActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/FlipActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/FlipActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class FlipActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/OnAwakeScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/OnAwakeScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class OnAwakeScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/OnEventScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/OnEventScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class OnEventScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/PlaySpriteAnimationActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/PlaySpriteAnimationActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class PlaySpriteAnimationActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/RootScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/RootScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class RootScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/SetAngleActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetAngleActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetScaleXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetScaleXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetScaleYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetScaleYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SpawnActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SpawnActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SpawnActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/SpriteScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SpriteScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SpriteScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/StartSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/StartSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartSceneActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/random/SetRandomXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/random/SetRandomXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "./GetRandom.js";
 import AssignOpComp from "../core/AssignOpComp.js";

--- a/browser/phaserjs_editor_scripts_quick/random/SetRandomYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/random/SetRandomYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "./GetRandom.js";
 import AssignOpComp from "../core/AssignOpComp.js";

--- a/browser/phaserjs_editor_scripts_quick/timer/DelayActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/DelayActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class DelayActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/timer/DelayRandomActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/DelayRandomActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "../random/GetRandom.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/timer/EmitRandomTickActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/EmitRandomTickActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "../random/GetRandom.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/timer/EmitTickActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/EmitTickActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class EmitTickActionScript extends ScriptNode {

--- a/build-browser.js
+++ b/build-browser.js
@@ -56,6 +56,9 @@ function processJSFiles(fromFolder, toFolder) {
 			const importRegex = /from "([^"]+)"/g;
 
 			content = content.replace(importRegex, (match, p1) => {
+				if (p1 === '@phaserjs/editor-scripts-base') {
+					return `from "../../phaserjs_editor_scripts_base/index.js"`;
+				}
 				return `from "${p1}.js"`;
 			});
 


### PR DESCRIPTION
Updated the build script to check if the `import` line for a file is
referencing the editor scripts base package, and when there is a match
the `import` statement will be changed from:

```js
from "@phaserjs/editor-scripts-base.js";
```

to

```js
from "../../phaserjs_editor_scripts_base/index.js";
```

This fix has a few limitations:

* if any other npm packages are added to this library, this change will
not fix those
* the generated `phaserjs_editor_scripts_quick` needs to be placed
at the root of the phaser editor project, next to the original location
of the `phaserjs_editor_scripts_base` folder.

After this change, I re-ran the `build-browser.js` script to create the new browser folder.